### PR TITLE
Fix index.qmd rendering to HTML-only (closes #85)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -7,18 +7,3 @@ project:
 
 execute:
   freeze: auto
-
-# Default format for presentations directory
-format:
-  beamer:
-    theme: Pittsburgh
-    colortheme: default
-    fonttheme: default
-    toc: true
-    toc-depth: 2
-    slide-level: 3
-    include-in-header:
-      - file: presentations/header.tex
-    template-partials:
-      - presentations/toc.tex
-    classoption: t

--- a/presentations/_quarto.yml
+++ b/presentations/_quarto.yml
@@ -1,0 +1,14 @@
+# Beamer format configuration for presentations
+format:
+  beamer:
+    theme: Pittsburgh
+    colortheme: default
+    fonttheme: default
+    toc: true
+    toc-depth: 2
+    slide-level: 3
+    include-in-header:
+      - file: header.tex
+    template-partials:
+      - toc.tex
+    classoption: t


### PR DESCRIPTION
## Summary
- Moved global beamer format configuration from root `_quarto.yml` to `presentations/_quarto.yml`
- This prevents `index.qmd` from being rendered as PDF, keeping it HTML-only for GitHub Pages
- Presentations in the `presentations/` directory continue to render as Beamer PDFs correctly

## Problem
The `index.qmd` file was being compiled to both HTML and PDF formats due to the global `format: beamer` configuration in the root `_quarto.yml`. This caused the GitHub Pages website to display the PDF version instead of the intended HTML landing page.

## Solution
Created a directory-specific configuration by moving the beamer format settings to `presentations/_quarto.yml`. This ensures that:
- `index.qmd` renders only to HTML (for the GitHub Pages landing page)
- Files in `presentations/` still render as Beamer PDFs (for slide presentations)

## Test plan
- [x] Verified `index.qmd` renders only to HTML (`html/index.html`)
- [x] Verified presentations still render correctly to PDF (tested with `01a-trigonometry-basic-identities.qmd`)
- [x] Confirmed no unwanted `index.pdf` is generated

Closes #85

🤖 Generated with [Claude Code](https://claude.ai/code)